### PR TITLE
Test for mod_rewrite even when PHP is run as CGI 

### DIFF
--- a/_install/index.php
+++ b/_install/index.php
@@ -307,17 +307,17 @@ function step1(){
 
 		$php_modules = (array) @apache_get_modules();
 		$l_modrewrite=(in_array('mod_rewrite',$php_modules)) ? 1:0;
-		$class_alert['modrewrite']= ($l_modrewrite) ? 'install-ok' : 'install-alert';
-		$alert_rewrite_na='';
 	}
 	// caso CGI
 	else{
 
 		$php_modules= array();
-		$l_modrewrite='na';
-		$class_alert['modrewrite']= 'install-na';
-		$alert_rewrite_na=_('This information is not available, since it seems to be using PHP as CGI');
+		require_once("../inc/func.mod_rewrite.php");
+		$doc_root="http://".$_SERVER['HTTP_HOST'].str_replace("/_install/index.php",'',$_SERVER['PHP_SELF']);
+		$l_modrewrite=(check_mod_rewrite($doc_root)) ? 1:0;
 	}
+	$class_alert['modrewrite']= ($l_modrewrite) ? 'install-ok' : 'install-alert';
+	$alert_rewrite_na='';
 
 	$l_mysqli=(in_array('mysqli',$ext)) ? 1:0;
 	$l_mysql_old=(in_array('mysql',$ext)) ? 1:0;

--- a/admin/vfront.info.php
+++ b/admin/vfront.info.php
@@ -295,11 +295,16 @@ $OUT.="<div class=\"piccolo\">"._("VFront requires register_globals to be disabl
 // IMPOSTAZIONI IMPORTANTI ---------------------------------------------------------------------------------------------------
 $OUT.="<h2 class=\"title-vfrontinfo\">"._("Apache Modules")."</h2>";
 
-$modules_apache=(array) @apache_get_modules();
+if(function_exists('apache_get_modules')){
+        $modules_apache=(array) @apache_get_modules();
+        $flog.="ApacheLoadedModules: ".implode(",",$modules_apache)."\n";
+        $apache_mod_rewrite=(in_array("mod_rewrite", $modules_apache)) ? "<span class=\"verde\">"._("YES")."</span>" : "<span class=\"rosso\">"._("NO")."</span>";
+}
+else{
+        $flog.="ApacheLoadedModules: apache_get_modules() not available\n";
+        $apache_mod_rewrite="<span class=\"rosso\">??? ("._('This information is not available, since it seems to be using PHP as CGI').")</span>";
+}
 
-$flog.="ApacheLoadedModules: ".implode(",",$modules_apache)."\n";
-
-$apache_mod_rewrite=(in_array("mod_rewrite", $modules_apache)) ? "<span class=\"verde\">"._("YES")."</span>" : "<span class=\"rosso\">"._("NO")."</span>";
 $OUT.="<span class=\"grigio\">"._("Mod_rewrite:")."</span> <strong>$apache_mod_rewrite</strong>\n";
 $OUT.="<div class=\"piccolo\">"._("VFront requires the use of mod_rewrite for different functions, such as generating reports")."</div><br />\n";
 

--- a/admin/vfront.info.php
+++ b/admin/vfront.info.php
@@ -302,7 +302,15 @@ if(function_exists('apache_get_modules')){
 }
 else{
         $flog.="ApacheLoadedModules: apache_get_modules() not available\n";
-        $apache_mod_rewrite="<span class=\"rosso\">??? ("._('This information is not available, since it seems to be using PHP as CGI').")</span>";
+        require_once("../inc/func.mod_rewrite.php");
+        if (check_mod_rewrite(FRONT_DOCROOT)) {
+                $flog.="mod_rewrite test succeeded\n";
+                $apache_mod_rewrite="<span class=\"verde\">"._("YES")."</span>";
+        }
+        else{
+                $flog.="mod_rewrite test failed\n";
+                $apache_mod_rewrite="<span class=\"rosso\">"._("NO")."</span>";
+        }
 }
 
 $OUT.="<span class=\"grigio\">"._("Mod_rewrite:")."</span> <strong>$apache_mod_rewrite</strong>\n";

--- a/inc/func.mod_rewrite.php
+++ b/inc/func.mod_rewrite.php
@@ -1,0 +1,8 @@
+<?php
+
+function check_mod_rewrite($root){
+        $test = file_get_contents($root.'/inc/mod_rewrite/test');
+        return $test == 'YES';
+}
+
+?>

--- a/inc/mod_rewrite/.htaccess
+++ b/inc/mod_rewrite/.htaccess
@@ -1,0 +1,4 @@
+<IfModule rewrite_module>
+RewriteEngine On
+RewriteRule ^test$ test.php
+</IfModule>

--- a/inc/mod_rewrite/test.php
+++ b/inc/mod_rewrite/test.php
@@ -1,0 +1,2 @@
+<?php
+print "YES";


### PR DESCRIPTION
The first commit fixes a bug in current `admin/vfront.info.php`, where `apache_get_modules()` is used without checking if it is available.
The second commit adds a test for the availability of `mod_rewrite` that seems to work even if PHP is run as CGI, since it directly tests if `mod_rewrite` is working.
I didn't squash them because you may judge that you are interested only in the first one.